### PR TITLE
Added mapping of media volume

### DIFF
--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -22,6 +22,7 @@ ports_description:
 map:
   - config:rw
   - share:rw
+  - media:rw
   - ssl
 options:
   system_packages: []


### PR DESCRIPTION
# Proposed Changes

> The change adds mapping of the `media` volume for AppDaemon so that it's possible to manipulate content stored there. For example add images to be used in Home Assistant.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
